### PR TITLE
Fix process.env overwrite order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figaro-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Env variable management in JS",
   "main": "lib/index.js",
   "bin": {

--- a/src/load.js
+++ b/src/load.js
@@ -34,7 +34,7 @@ import read from './read'
 
 function load (options) {
   const readEnv = read(options)
-  process.env = { ...readEnv, ...process.env }
+  process.env = { ...process.env, ...readEnv }
 }
 
 export default load

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -12,3 +12,12 @@ test('adds new env object to process.env', () => {
   })
   expect(process.env).toEqual({ ...priorProcessEnv, ...DEVELOPMENT_ENV })
 })
+
+test('overwrites existing vars in process.env', () => {
+  process.env.SHARED_VAR = 'something'
+  load({
+    path: CONFIG_FILE_PATH,
+    environment: 'development',
+  })
+  expect(process.env.SHARED_VAR).toEqual(DEVELOPMENT_ENV.SHARED_VAR)
+})


### PR DESCRIPTION
I think this is the expected behavior.