### PR TITLE
Add values to process.env in place

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figaro-js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Env variable management in JS",
   "main": "lib/index.js",
   "bin": {

--- a/src/load.js
+++ b/src/load.js
@@ -34,7 +34,7 @@ import read from './read'
 
 function load (options) {
   const readEnv = read(options)
-  process.env = { ...process.env, ...readEnv }
+  Object.assign(process.env, readEnv)
 }
 
 export default load

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -21,3 +21,12 @@ test('overwrites existing vars in process.env', () => {
   })
   expect(process.env.SHARED_VAR).toEqual(DEVELOPMENT_ENV.SHARED_VAR)
 })
+
+test('modifies process.env in place', () => {
+  const processEnvReference = process.env
+  load({
+    path: CONFIG_FILE_PATH,
+    environment: 'development',
+  })
+  expect(process.env).toBe(processEnvReference)
+})


### PR DESCRIPTION
Replacing the entire object was leading to bugs with react static. This is probably somewhat react static's fault, but we should really be adding values to the global object rather than replacing it.